### PR TITLE
add demo agent header to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
               nvm alias default v14.15.1
       - run:
           name: Get ACAPy
-          command: docker pull bcgovimages/aries-cloudagent:py36-1.16-1_0.7.0
+          command: docker pull bcgovimages/aries-cloudagent:py36-1.16-1_0.7.1
       - run:
           name: Start docker compose and wait for readiness
           command: |
@@ -40,7 +40,7 @@ jobs:
           name: Setup integration tests
           command: |
             npm install
-            sleep 10
+            sleep 5
             ./scripts/setup_fixtures.sh
       - run:
           name: Running integration tests (only health tests for now)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
           name: Setup integration tests
           command: |
             npm install
+            sleep 10
             ./scripts/setup_fixtures.sh
       - run:
           name: Running integration tests (only health tests for now)

--- a/dummy.env
+++ b/dummy.env
@@ -8,4 +8,4 @@ ARIES_GUARDIANSHIP_AGENCY_IMAGE=kivaprotocol/aries-guardianship-agency:latest
 ARIES_KEY_GUARDIAN_IMAGE=kivaprotocol/aries-key-guardian:latest
 KIVA_CONTROLLER_IMAGE=kivaprotocol/kiva-controller:latest
 FSP_CONTROLLER_IMAGE=kivaprotocol/fsp-controller:latest
-DEMO_CONTROLLER_IMAGE=kivaprotocol/demo-controller:latest
+DEMO_CONTROLLER_IMAGE=kivaprotocol/aries-controller:latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -6213,9 +6213,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",

--- a/scripts/setup_demo_controller.sh
+++ b/scripts/setup_demo_controller.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# The demo controller is different than the others as it uses the generic aries-controller docker image, so doesn't have
+# the setup scripts inside the container. Instead there's a series of curl calls that can be run to accomplish the same affect.
+# This is copied from https://github.com/kiva/protocol-demo/blob/main/scripts/setup_controller.sh and any changes there 
+# should be reflected here too
+set -ev
+
+# Register demo agent
+curl --location --request POST 'http://localhost:3014/v2/api/agent/register' \
+--header 'agent: demo-agent' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "seed": "000000000000000000000000Steward2",
+    "label": "Demo Controller",
+    "useTailsServer": false,
+    "adminApiKey": "demoAdminApiKey"
+}'
+
+# Publicize DID
+curl --location --request POST 'http://localhost:3014/v1/agent/publicize-did' \
+--header 'agent: demo-agent' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "did": "EbP4aYNeTHL6q385GuVpRV"
+}'
+
+# Add schema and cred def
+curl --location --request POST 'http://localhost:3014/v2/api/schema-cred-def' \
+--header 'agent: demo-agent' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "schemaName": "Identity",
+    "attributes": [
+        "nationalId",
+        "firstName",
+        "lastName",
+        "birthDate",
+        "photo~attach"
+    ],
+    "schemaVersion": "1.0.0",
+    "schemaProfileName": "demo.schema.json",
+    "schemaComment": "Identity schema for demo",
+    "tag": "tag1",
+    "supportRevocation": false,
+    "credDefcomment": "Nationa ID card",
+    "credDefProfileName": "demo.cred.def.json"
+}'
+
+# Add proof requets
+curl --location --request POST 'http://localhost:3014/v2/api/profiles' \
+--header 'agent: demo-agent' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "profileName": "demo.proof.request.json",
+    "profile": {
+        "comment":"Proof for the demo",
+        "proof_request":{
+            "name":"Demo",
+            "version":"1.0",
+            "requested_attributes":{
+                "nationalId":{
+                    "name":"nationalId",
+                    "restrictions": [{
+                        "issuer_did":"EbP4aYNeTHL6q385GuVpRV"
+                    }]
+                },
+                "firstName":{
+                    "name":"firstName",
+                    "restrictions": [{
+                        "issuer_did":"EbP4aYNeTHL6q385GuVpRV"
+                    }]
+                },
+                "lastName":{
+                    "name":"lastName",
+                    "restrictions": [{
+                        "issuer_did":"EbP4aYNeTHL6q385GuVpRV"
+                    }]
+                },
+                "birthDate":{
+                    "name":"birthDate",
+                    "restrictions": [{
+                        "issuer_did":"EbP4aYNeTHL6q385GuVpRV"
+                    }]
+                },
+                "photo~attach":{
+                    "name":"photo~attach",
+                    "restrictions": [{
+                        "issuer_did":"EbP4aYNeTHL6q385GuVpRV"
+                    }]
+                }
+            },
+            "requested_predicates":{}
+        }
+    }
+}'
+
+curl --location --request POST 'http://localhost:3014/v2/api/profiles' \
+--header 'agent: demo-agent' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "profileName": "demo.proof.request.json",
+    "profile": {
+        "comment":"Unrestricted proof for the demo",
+        "proof_request":{
+            "name":"UnrestrictedDemo",
+            "version":"1.0",
+            "requested_attributes":{
+                "nationalId":{
+                    "name":"nationalId",
+                    "restrictions": []
+                },
+                "firstName":{
+                    "name":"firstName",
+                    "restrictions": []
+                },
+                "lastName":{
+                    "name":"lastName",
+                    "restrictions": []
+                },
+                "birthDate":{
+                    "name":"birthDate",
+                    "restrictions": []
+                },
+                "photo~attach":{
+                    "name":"photo~attach",
+                    "restrictions": []
+                }
+            },
+            "requested_predicates":{}
+        }
+    }
+}'
+# Done

--- a/scripts/setup_fixtures.sh
+++ b/scripts/setup_fixtures.sh
@@ -5,5 +5,5 @@ set -ev
 
 sleep 1
 docker exec -it kiva-controller node /www/scripts/setup.sl.kiva.js
-docker exec -it demo-controller node /www/scripts/setup.demo.js
 docker exec -it kiva-controller node /www/scripts/setup.employee.kiva.js
+./scripts/setup_demo_controller.sh

--- a/services/demo_controller/test.env
+++ b/services/demo_controller/test.env
@@ -5,13 +5,5 @@
 NODE_ENV=LOCAL
 PORT=3014
 SELF_URL=http://demo-controller:3014
-
-# Demo Profile
-WALLET_ID=demoWalletId
-WALLET_KEY=demoWalletKey
-ADMIN_API_KEY=demoApiKey
-SEED=000000000000000000000000Steward2
-
-# Auth0 - TODO these could be configs but need to figure out how to add on implementation specific configs
-AUTH0_ALGORITHM=RS256
-AUTH0_DOMAIN=kiva-protocol-standalone.auth0.com
+MULTI_AGENT=false
+MULTI_CONTROLLER=true

--- a/test/v2.remote.demo.flow.e2e-spec.ts
+++ b/test/v2.remote.demo.flow.e2e-spec.ts
@@ -58,6 +58,7 @@ describe('Full system eKYC integration tests for demo issue and verify flows', (
         return request(process.env.API_GATEWAY_URL)
             .post('/v2/demo/api/connection')
             .set(AUTH0_HEADER, auth0Token)
+            .set('agent', 'demo-agent')
             .expect(201)
             .expect((res) => {
                 expect(res.body.invitation).toBeDefined();
@@ -88,6 +89,7 @@ describe('Full system eKYC integration tests for demo issue and verify flows', (
         return request(process.env.API_GATEWAY_URL)
             .get(`/v2/demo/api/connection/${demoConnectionId}`)
             .set(AUTH0_HEADER, auth0Token)
+            .set('agent', 'demo-agent')
             .expect(200)
             .expect((res) => {
                 expect(res.body.state).toBe('response');
@@ -110,6 +112,7 @@ describe('Full system eKYC integration tests for demo issue and verify flows', (
         return request(process.env.API_GATEWAY_URL)
             .post('/v2/demo/api/issue')
             .set(AUTH0_HEADER, auth0Token)
+            .set('agent', 'demo-agent')
             .send(issueData)
             .expect((res) => {
                 try {
@@ -133,6 +136,7 @@ describe('Full system eKYC integration tests for demo issue and verify flows', (
         return request(process.env.API_GATEWAY_URL)
             .post(`/v2/demo/api/verify`)
             .set(AUTH0_HEADER, auth0Token)
+            .set('agent', 'demo-agent')
             .send(data)
             .expect((res) => {
                 try {
@@ -152,6 +156,7 @@ describe('Full system eKYC integration tests for demo issue and verify flows', (
         return request(process.env.API_GATEWAY_URL)
             .get(`/v2/demo/api/verify/${presExId}`)
             .set(AUTH0_HEADER, auth0Token)
+            .set('agent', 'demo-agent')
             .expect(200)
             .expect((res) => {
                 expect(res.body.state).toBe('verified');
@@ -165,6 +170,7 @@ describe('Full system eKYC integration tests for demo issue and verify flows', (
         return request(process.env.API_GATEWAY_URL)
             .get(`/v2/demo/api/connection/${demoConnectionId}`)
             .set(AUTH0_HEADER, auth0Token)
+            .set('agent', 'demo-agent')
             .expect(200)
             .expect((res) => {
                 expect(res.body.state).toBe('active');
@@ -176,6 +182,7 @@ describe('Full system eKYC integration tests for demo issue and verify flows', (
         return request(process.env.API_GATEWAY_URL)
             .delete(`/v2/demo/api/connection/${demoConnectionId}`)
             .set(AUTH0_HEADER, auth0Token)
+            .set('agent', 'demo-agent')
             .expect(200);
     });
 });

--- a/test/v2.remote.employee.mobile.e2e-spec.ts
+++ b/test/v2.remote.employee.mobile.e2e-spec.ts
@@ -69,6 +69,7 @@ describe('Full system issue and verify flows for employee credentials', () => {
         return request(process.env.API_GATEWAY_URL)
             .post('/v2/demo/agent/accept-connection')
             .set('Authorization', auth0Token)
+            .set('agent', 'demo-agent')
             .send(data)
             .expect((res) => {
                 expect(res.status).toBe(201);


### PR DESCRIPTION
@jeffk-kiva I made a few changes since you latest review
Essentially we've changed how the demo-controller works, instead of being it's own docker image, we just set it up as a multi-controller and have it use the generic aries-controller image. One extra advantage here, is that we can have these integration tests run against aries-controller now, which used to be just an npm package but now is a docker image too.
Signed-off-by: Jacob Saur <jsaur@kiva.org>